### PR TITLE
Correct a bug and changes y-axis scale of jacobian and opacity plot

### DIFF
--- a/exercises/05-jacobian/jacobian_module.py
+++ b/exercises/05-jacobian/jacobian_module.py
@@ -98,11 +98,10 @@ def plot_opacity(
 
 
 def plot_jacobian(
-    height, jacobian, jacobian_quantity, plotsize=SUBPLOT_WIDTH, aspect=ASPECT_RATIO
-):
+    height, jacobian, jacobian_quantity, plotsize=SUBPLOT_WIDTH, aspect=ASPECT_RATIO):
     p = figure(
-        y_axis_type="log",
-        y_range=(0.4, 70),
+        y_axis_type="linear",
+        y_range=(0.4, 20),
         tooltips=[("x", "$x"), ("value", "@y")],
         width=plotsize,
         aspect_ratio=aspect,
@@ -138,9 +137,9 @@ def plot_jacobian(
 def plot_opacity_profile(height, opacity, plotsize=SUBPLOT_WIDTH, aspect=ASPECT_RATIO):
     p = figure(
         x_axis_type="log",
-        y_axis_type="log",
+        y_axis_type="linear",
         x_range=(1e-8, 1e2),
-        y_range=(0.4, 70),
+        y_range=(0.4, 20),
         tooltips=[("x", "$x"), ("value", "@y")],
         width=plotsize,
         aspect_ratio=aspect,
@@ -177,7 +176,7 @@ def plot_opacity_profile(height, opacity, plotsize=SUBPLOT_WIDTH, aspect=ASPECT_
         vline = Span(location=1, dimension="height", line_color="grey", line_width=0.8)
         p.renderers.extend([vline])
 
-        return p
+    return p
 
 
 def calc_jacobians(

--- a/exercises/05-jacobian/jacobian_module_mpl.py
+++ b/exercises/05-jacobian/jacobian_module_mpl.py
@@ -67,8 +67,8 @@ def plot_jacobian(height, jacobian, jacobian_quantity, ax=None):
     if ax is None:
         ax = plt.gca()
 
-    ax.semilogy(jacobian, height / 1000.0)
-    ax.set_ylim(0.4, 70)
+    ax.plot(jacobian, height / 1000.0)
+    ax.set_ylim(0.4, 20)
     unit = "K/K/km" if jacobian_quantity == "T" else "K/1/km"
     ax.set_xlabel(f"{tag2tex(jacobian_quantity)} Jacobian [{unit}]")
     ax.set_ylabel("$z$ [km]")
@@ -93,11 +93,11 @@ def plot_opacity_profile(height, opacity, ax=None):
     if ax is None:
         ax = plt.gca()
 
-    ax.loglog(opacity, height[::-1] / 1000.0)
+    ax.semilogx(opacity, height[::-1] / 1000.0)
     ax.set_xlim(1e-8, 1e2)
     ax.set_xticks(10.0 ** np.arange(-8, 4, 2))
     ax.set_xlabel(r"Opacity $\tau(z, z_\mathrm{TOA})$")
-    ax.set_ylim(0.4, 70)
+    ax.set_ylim(0.4, 20)
     ax.set_ylabel("$z$ [km]")
 
     try:
@@ -186,11 +186,11 @@ def calc_jacobians(
     ws.abs_lines_per_speciesReadSpeciesSplitCatalog(
        basename="spectroscopy/Hitran/"
     )
-    
+
     # ws.abs_lines_per_speciesSetLineShapeType(option=lineshape)
     ws.abs_lines_per_speciesSetCutoff(option="ByLine", value=750e9)
     # ws.abs_lines_per_speciesSetNormalization(option=normalization)
-    
+
     # Create a frequency grid
     ws.VectorNLinSpace(ws.f_grid, int(fnum), float(fmin), float(fmax))
 


### PR DESCRIPTION
* The return statement  had a wrong indentation in plot_opacity_profile. 
  This resulted that for frequencies ~<160 GHz the function had no return
  value.

* The yaxis of the jacobian  and the opacity profile plot were changed to
  linear scale. Furthermore the yaxis limit were set to 20 km. Above 20km
  nothing happens. So, no need to show something.