### PR TITLE
Update lecture 04-rtcalc for arts 2.5.6 and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ The exercises make use of the ARTS Python API.
 
 Required ARTS version pre-release 2.5.6
 
-Students attending the course at Universität Hamburg use VDI system of cen [here][vdi-cen].
+Matching catalogs are [available here][cats].
+
+Students attending the course at Universität Hamburg use VDI system of CEN [here][vdi-cen].
 
 [arts]: http://radiativetransfer.org/
 [vdi-cen]: https://www.cen.uni-hamburg.de/facilities/cen-it/vdi.html
-[typhon-github]: https://github.com/atmtools/typhon
+[typhon-github]: https://github.com/atmtools/typhon/
+[cats]: https://www.radiativetransfer.org/misc/download/unstable/

--- a/exercises/01-molecule_spectra/absorption_module.py
+++ b/exercises/01-molecule_spectra/absorption_module.py
@@ -1,10 +1,8 @@
 """Calculate and plot absorption cross sections."""
 import re
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pyarts
-from typhon.plots import styles
 
 
 def tag2tex(tag):

--- a/exercises/04-rtcalc/rtcalc_module.py
+++ b/exercises/04-rtcalc/rtcalc_module.py
@@ -1,9 +1,7 @@
 """Calculate and plot zenith opacity and brightness temperatures. """
 import re
 
-import matplotlib.pyplot as plt
 import numpy as np
-import typhon as ty
 import pyarts.workspace
 
 
@@ -36,32 +34,16 @@ def run_arts(
           Frequency grid [Hz], Brightness temperature [K], Optical depth [1]
     """
     ws = pyarts.workspace.Workspace(verbosity=0)
-    ws.execute_controlfile("general/general.arts")
-    ws.execute_controlfile("general/continua.arts")
-    ws.execute_controlfile("general/agendas.arts")
-    ws.execute_controlfile("general/planet_earth.arts")
+    ws.LegacyContinuaInit()
+    ws.water_p_eq_agendaSet()
+    ws.PlanetSet(option="Earth")
+    ws.iy_main_agendaSet(option="Emission")
+    ws.ppath_agendaSet(option="FollowSensorLosPath")
+    ws.ppath_step_agendaSet(option="GeometricPath")
+    ws.iy_space_agendaSet(option="CosmicBackground")
+    ws.iy_surface_agendaSet(option="UseSurfaceRtprop")
+
     ws.verbositySetScreen(ws.verbosity, verbosity)
-
-    # Agenda for scalar gas absorption calculation
-    ws.Copy(ws.abs_xsec_agenda, ws.abs_xsec_agenda__noCIA)
-
-    # (standard) emission calculation
-    ws.Copy(ws.iy_main_agenda, ws.iy_main_agenda__Emission)
-
-    # cosmic background radiation
-    ws.Copy(ws.iy_space_agenda, ws.iy_space_agenda__CosmicBackground)
-
-    # standard surface agenda (i.e., make use of surface_rtprop_agenda)
-    ws.Copy(ws.iy_surface_agenda, ws.iy_surface_agenda__UseSurfaceRtprop)
-
-    # on-the-fly absorption
-    ws.Copy(ws.propmat_clearsky_agenda, ws.propmat_clearsky_agenda__OnTheFly)
-
-    # sensor-only path
-    ws.Copy(ws.ppath_agenda, ws.ppath_agenda__FollowSensorLosPath)
-
-    # no refraction
-    ws.Copy(ws.ppath_step_agenda, ws.ppath_step_agenda__GeometricPath)
 
     # Number of Stokes components to be computed
     ws.IndexSet(ws.stokes_dim, 1)
@@ -78,14 +60,16 @@ def run_arts(
     ws.abs_speciesSet(species=species)
 
     # Read a line file and a matching small frequency grid
-    ws.abs_lines_per_speciesReadSpeciesSplitCatalog(
-       basename="spectroscopy/Artscat/"
-    )
+    ws.abs_lines_per_speciesReadSpeciesSplitCatalog(basename="lines/")
 
-    # ws.abs_lines_per_speciesSetLineShapeType(option=lineshape)
-    ws.abs_lines_per_speciesSetCutoff(option="ByLine", value=750e9)
-    # ws.abs_lines_per_speciesSetNormalization(option=normalization)
-    
+    # FIXME OLE: Cutoff requires line mixing for O2 to be turned off, but
+    # abs_lines_per_speciesTurnOffLineMixing is not yet available in 2.5.6.
+    # We might need an updated conda package because without Cutoff the
+    # calculation takes too much time.
+
+    # ws.abs_lines_per_speciesCutoff(option="ByLine", value=750e9)
+    # ws.abs_lines_per_speciesTurnOffLineMixing()
+
     # Create a frequency grid
     ws.VectorNLinSpace(ws.f_grid, int(fnum), float(fmin), float(fmax))
 
@@ -93,14 +77,13 @@ def run_arts(
     ws.abs_lines_per_speciesCompact()
 
     # Atmospheric scenario
-    ws.AtmRawRead(basename="planets/Earth/Fascod/midlatitude-summer/midlatitude-summer")
+    ws.AtmRawRead(
+        basename="planets/Earth/Fascod/midlatitude-summer/midlatitude-summer")
 
     # Non reflecting surface
     ws.VectorSetConstant(ws.surface_scalar_reflectivity, 1, 0.1)
-    ws.Copy(
-        ws.surface_rtprop_agenda,
-        ws.surface_rtprop_agenda__Specular_NoPol_ReflFix_SurfTFromt_surface,
-    )
+    ws.surface_rtprop_agendaSet(
+        option="Specular_NoPol_ReflFix_SurfTFromt_surface")
 
     # No sensor properties
     ws.sensorOff()
@@ -122,7 +105,7 @@ def run_arts(
     ws.MatrixSet(ws.sensor_los, np.array([[zenith_angle]]))
 
     # Perform RT calculations
-    ws.abs_xsec_agenda_checkedCalc()
+    ws.propmat_clearsky_agendaAuto()
     ws.lbl_checkedCalc()
     ws.propmat_clearsky_agenda_checkedCalc()
     ws.atmfields_checkedCalc()
@@ -131,4 +114,5 @@ def run_arts(
     ws.sensor_checkedCalc()
     ws.yCalc()
 
-    return (ws.f_grid.value.copy(), ws.y.value.copy(), ws.y_aux.value[0].data.copy())
+    return (ws.f_grid.value[:].copy(), ws.y.value[:].copy(),
+            ws.y_aux.value[0][:].copy())


### PR DESCRIPTION
There is still an issue with exe 04 since it uses O2 which forces linemixing automatically on. This prevents the use of a cutoff frequency because `abs_lines_per_speciesTurnOffLineMixing` was only added in a later version and leads to prolonged calculation times.