### PR TITLE
Update to pyarts 2.5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ mamba activate arts-lectures
 jupyter-lab exercises
 ```
 
-Students attending the course at Universität Hamburg use VDI system of CEN [here][vdi-cen].
+Students attending the course at Universität Hamburg use the [VDI system of CEN][vdi-cen].
 
 [arts]: http://radiativetransfer.org/
 [vdi-cen]: https://www.cen.uni-hamburg.de/facilities/cen-it/vdi.html

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - ipympl
   - jupyterlab
-  - pyarts=2.5.6
+  - pyarts=2.5.8
   - python=3.10
   - typhon
 

--- a/exercises/01-molecule_spectra/absorption_module.py
+++ b/exercises/01-molecule_spectra/absorption_module.py
@@ -54,7 +54,6 @@ def calculate_absxsec(species="N2O",
     """
     # Create ARTS workspace and load default settings
     ws = pyarts.workspace.Workspace(verbosity=0)
-    ws.LegacyContinuaInit()
     ws.water_p_eq_agendaSet()
     ws.PlanetSet(option="Earth")
 
@@ -96,7 +95,7 @@ def calculate_absxsec(species="N2O",
     ws.propmat_clearsky_agenda_checked = 1
     ws.propmat_clearskyInit()
     ws.propmat_clearskyAddLines()
-    ws.propmat_clearskyAddConts()
+    ws.propmat_clearskyAddPredefined()
 
     # Convert abs coeff to cross sections on return
     number_density = pressure * vmr / (pyarts.arts.constant.k * temperature)

--- a/exercises/02-line_shape/lineshape_module.py
+++ b/exercises/02-line_shape/lineshape_module.py
@@ -163,7 +163,6 @@ def calculate_absxsec(species="N2O",
 
     if ws is None or reload:
         ws = pyarts.workspace.Workspace(verbosity=0)
-        ws.LegacyContinuaInit()
         ws.water_p_eq_agendaSet()
         ws.PlanetSet(option="Earth")
 
@@ -205,7 +204,7 @@ def calculate_absxsec(species="N2O",
     ws.propmat_clearsky_agenda_checked = 1
     ws.propmat_clearskyInit()
     ws.propmat_clearskyAddLines()
-    ws.propmat_clearskyAddConts()
+    ws.propmat_clearskyAddPredefined()
 
     # Convert abs coeff to cross sections on return
     number_density = pressure * vmr / (pyarts.arts.constant.k * temperature)

--- a/exercises/04-rtcalc/rtcalc_module.py
+++ b/exercises/04-rtcalc/rtcalc_module.py
@@ -5,8 +5,6 @@ import numpy as np
 import pyarts.workspace
 
 
-if pyarts.version != "2.5.6":
-    raise RuntimeError("Requires 2.5.6: Remove dirty lm+cutoff workaround before updating")
 def tags2tex(tags):
     """Replace all numbers in every species tag with LaTeX subscripts."""
     return [re.sub("([a-zA-Z]+)([0-9]+)", r"\1$_{\2}$", tag) for tag in tags]
@@ -36,7 +34,6 @@ def run_arts(
           Frequency grid [Hz], Brightness temperature [K], Optical depth [1]
     """
     ws = pyarts.workspace.Workspace(verbosity=0)
-    ws.LegacyContinuaInit()
     ws.water_p_eq_agendaSet()
     ws.PlanetSet(option="Earth")
     ws.iy_main_agendaSet(option="Emission")
@@ -64,12 +61,8 @@ def run_arts(
     # Read a line file and a matching small frequency grid
     ws.abs_lines_per_speciesReadSpeciesSplitCatalog(basename="lines/")
 
-    # FIXME OLE: Cutoff requires line mixing for O2 to be turned off, but
-    # abs_lines_per_speciesTurnOffLineMixing is not yet available in 2.5.6.
-    # Workaround is forcing lbl_checked to true
     ws.abs_lines_per_speciesCutoff(option="ByLine", value=750e9)
-    ws.lbl_checked = 1
-    # ws.abs_lines_per_speciesTurnOffLineMixing()
+    ws.abs_lines_per_speciesTurnOffLineMixing()
 
     # Create a frequency grid
     ws.VectorNLinSpace(ws.f_grid, int(fnum), float(fmin), float(fmax))
@@ -107,8 +100,7 @@ def run_arts(
 
     # Perform RT calculations
     ws.propmat_clearsky_agendaAuto()
-    # FIXME OLE: Commented out for linemixing + cutoff workaround
-    # ws.lbl_checkedCalc()
+    ws.lbl_checkedCalc()
     ws.propmat_clearsky_agenda_checkedCalc()
     ws.atmfields_checkedCalc()
     ws.atmgeom_checkedCalc()

--- a/exercises/06-inversion/oem_module.py
+++ b/exercises/06-inversion/oem_module.py
@@ -16,7 +16,6 @@ def forward_model(f_grid, atm_fields_compact, verbosity=0):
         ndarray, ndarray: Frequency grid [Hz], Jacobian [K/1]
     """
     ws = pyarts.workspace.Workspace(verbosity=0)
-    ws.LegacyContinuaInit()
     ws.water_p_eq_agendaSet()
     ws.PlanetSet(option="Earth")
     ws.verbositySetScreen(ws.verbosity, verbosity)
@@ -47,12 +46,15 @@ def forward_model(f_grid, atm_fields_compact, verbosity=0):
 
     # Definition of absorption species
     ws.abs_speciesSet(species=[
-        "H2O, H2O-SelfContCKDMT252, H2O-ForeignContCKDMT252",
+        "H2O, H2O-SelfContCKDMT400, H2O-ForeignContCKDMT400",
         "O2-TRE05",
         "N2, N2-CIAfunCKDMT252, N2-CIArotCKDMT252",
     ])
 
     ws.abs_lines_per_speciesReadSpeciesSplitCatalog(basename="lines/")
+
+    # Load CKDMT400 model data
+    ws.ReadXML(ws.predefined_model_data, "model/mt_ckd_4.0/H2O.xml")
 
     # ws.abs_lines_per_speciesLineShapeType(option=lineshape)
     ws.abs_lines_per_speciesCutoff(option="ByLine", value=750e9)
@@ -97,7 +99,7 @@ def forward_model(f_grid, atm_fields_compact, verbosity=0):
         g1=ws.p_grid,
         g2=ws.lat_grid,
         g3=ws.lon_grid,
-        species="H2O, H2O-SelfContCKDMT252, H2O-ForeignContCKDMT252",
+        species="H2O, H2O-SelfContCKDMT400, H2O-ForeignContCKDMT400",
         unit="vmr",
     )
     ws.jacobianClose()

--- a/exercises/07-olr/olr_module.py
+++ b/exercises/07-olr/olr_module.py
@@ -26,7 +26,6 @@ def calc_olr(atmfield,
         ndarray, ndarray: Frequency grid [Hz], OLR [Wm^-2]
     """
     ws = pyarts.workspace.Workspace(verbosity=0)
-    ws.LegacyContinuaInit()
     ws.water_p_eq_agendaSet()
     ws.gas_scattering_agendaSet()
     ws.PlanetSet(option="Earth")
@@ -45,7 +44,7 @@ def calc_olr(atmfield,
     # Definition of species
     if species == 'default':
         ws.abs_speciesSet(species=[
-            "H2O, H2O-SelfContCKDMT350, H2O-ForeignContCKDMT350",
+            "H2O, H2O-SelfContCKDMT400, H2O-ForeignContCKDMT400",
             "CO2, CO2-CKDMT252",
         ])
     else:
@@ -53,6 +52,9 @@ def calc_olr(atmfield,
 
     # Read line catalog
     ws.abs_lines_per_speciesReadSpeciesSplitCatalog(basename="lines/")
+
+    # Load CKDMT400 model data
+    ws.ReadXML(ws.predefined_model_data, "model/mt_ckd_4.0/H2O.xml")
 
     # Read cross section data
     ws.ReadXsecData(basename="lines/")

--- a/exercises/08-scattering/scattering_module.py
+++ b/exercises/08-scattering/scattering_module.py
@@ -83,7 +83,6 @@ def scattering(ice_water_path=2.0,
 
     """
     ws = pyarts.workspace.Workspace(verbosity=0)
-    ws.LegacyContinuaInit()
     ws.water_p_eq_agendaSet()
     ws.PlanetSet(option="Earth")
 
@@ -121,7 +120,7 @@ def scattering(ice_water_path=2.0,
 
     # Set absorption species
     ws.abs_speciesSet(
-        species=["H2O-PWR98", "O3", "O2-PWR93", "N2-SelfContStandardType"])
+        species=["H2O-PWR98", "O3", "O2-PWR98", "N2-SelfContStandardType"])
 
     # Read atmospheric data
     ws.ReadXML(ws.batch_atm_fields_compact,

--- a/exercises/09_heating_rates/heating_rates_module.py
+++ b/exercises/09_heating_rates/heating_rates_module.py
@@ -29,7 +29,6 @@ def calc_spectral_irradiance(atmfield,
         spectral upward irradiance [Wm^-2 Hz^-1].
     """
     ws = pyarts.workspace.Workspace(verbosity=0)
-    ws.LegacyContinuaInit()
     ws.water_p_eq_agendaSet()
     ws.gas_scattering_agendaSet()
     ws.PlanetSet(option="Earth")
@@ -61,12 +60,15 @@ def calc_spectral_irradiance(atmfield,
 
     # Definition of species
     ws.abs_speciesSet(species=[
-        "H2O,H2O-SelfContCKDMT252, H2O-ForeignContCKDMT252",
+        "H2O, H2O-SelfContCKDMT400, H2O-ForeignContCKDMT400",
         "CO2, CO2-CKDMT252"
     ])
 
     # Read line catalog
     ws.abs_lines_per_speciesReadSpeciesSplitCatalog(basename="lines/")
+
+    # Load CKDMT400 model data
+    ws.ReadXML(ws.predefined_model_data, "model/mt_ckd_4.0/H2O.xml")
 
     # ws.abs_lines_per_speciesLineShapeType(option=lineshape)
     ws.abs_lines_per_speciesCutoff(option="ByLine", value=750e9)


### PR DESCRIPTION
Remove LegacyContinuaInit.
Replace propmat_clearskyAddConts with propmat_clearskyAddPredefined.
Replace workaround for turning off linemixing with
abs_lines_per_speciesTurnOffLineMixing.
Use newer CKDMT400 for H2O.
Use newer PWR98 for O2.