### PR TITLE
Add check for too low frequency

### DIFF
--- a/exercises/06-olr/olr.py
+++ b/exercises/06-olr/olr.py
@@ -16,7 +16,7 @@ def calc_olr_from_profiles(
     surface_altitude=0.0,
     nstreams=10,
     fnum=300,
-    fmin=1.0,
+    fmin=1e6,
     fmax=75e12,
     verbosity=0,
 ):
@@ -44,6 +44,9 @@ def calc_olr_from_profiles(
         ndarray, ndarray: Frequency grid [Hz], OLR [Wm^-2]
 
     """
+
+    if fmin < 1e6:
+        raise RuntimeError('fmin must be >= 1e6 Hz')
 
     ws = pyarts.workspace.Workspace(verbosity=0)
     ws.water_p_eq_agendaSet()


### PR DESCRIPTION
This pull request adds a check for too low frequency in the `calc_olr_from_profiles` function. If `fmin` is less than 1e6 Hz, a `RuntimeError` will be raised. This ensures that the function is only called with valid input parameters.

No issue number is referenced in this pull request.